### PR TITLE
[headless-svc] Support external node IPs.

### DIFF
--- a/source/service_test.go
+++ b/source/service_test.go
@@ -3022,6 +3022,181 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 	}
 }
 
+// TestHeadlessServices tests that headless services generate the correct endpoints.
+func TestHeadlessServicesExternalHostIP(t *testing.T) {
+	for _, tc := range []struct {
+		title                    string
+		targetNamespace          string
+		svcNamespace             string
+		svcName                  string
+		svcType                  v1.ServiceType
+		compatibility            string
+		fqdnTemplate             string
+		ignoreHostnameAnnotation bool
+		labels                   map[string]string
+		annotations              map[string]string
+		clusterIP                string
+		hostIPs                  []string
+		selector                 map[string]string
+		lbs                      []string
+		podnames                 []string
+		hostnames                []string
+		podsReady                []bool
+		publishNotReadyAddresses bool
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+	}{
+		{
+			"annotated Headless services return endpoints for each selected Pod",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			false,
+			map[string]string{"component": "foo"},
+			map[string]string{
+				hostnameAnnotationKey:   "service.example.org",
+				externalIPAnnotationKey: "true",
+			},
+			v1.ClusterIPNone,
+			[]string{"4.3.2.1", "5.4.3.2"},
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo-0", "foo-1"},
+			[]string{"foo-0", "foo-1"},
+			[]bool{true, true},
+			false,
+			[]*endpoint.Endpoint{
+				{DNSName: "foo-0.service.example.org", Targets: endpoint.Targets{"4.3.2.1"}},
+				{DNSName: "foo-1.service.example.org", Targets: endpoint.Targets{"5.4.3.2"}},
+				{DNSName: "service.example.org", Targets: endpoint.Targets{"4.3.2.1", "5.4.3.2"}},
+			},
+			false,
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			// Create a Kubernetes testing client
+			kubernetes := fake.NewSimpleClientset()
+
+			service := &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type:                     tc.svcType,
+					ClusterIP:                tc.clusterIP,
+					Selector:                 tc.selector,
+					PublishNotReadyAddresses: tc.publishNotReadyAddresses,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   tc.svcNamespace,
+					Name:        tc.svcName,
+					Labels:      tc.labels,
+					Annotations: tc.annotations,
+				},
+				Status: v1.ServiceStatus{},
+			}
+			_, err := kubernetes.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			var addresses, notReadyAddresses []v1.EndpointAddress
+			for i, podname := range tc.podnames {
+				node := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-" + podname,
+					},
+					Spec: v1.NodeSpec{},
+					Status: v1.NodeStatus{
+						Addresses: []v1.NodeAddress{
+							{Type: v1.NodeExternalIP, Address: tc.hostIPs[i]},
+							{Type: v1.NodeInternalIP, Address: "10.1.2.3"},
+							{Type: v1.NodeHostName, Address: "node-" + podname},
+						},
+					},
+				}
+				_, err = kubernetes.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+				require.NoError(t, err)
+
+				pod := &v1.Pod{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{},
+						Hostname:   tc.hostnames[i],
+						NodeName:   node.Name,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   tc.svcNamespace,
+						Name:        podname,
+						Labels:      tc.labels,
+						Annotations: tc.annotations,
+					},
+					Status: v1.PodStatus{
+						HostIP: tc.hostIPs[i],
+					},
+				}
+
+				_, err = kubernetes.CoreV1().Pods(tc.svcNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
+				require.NoError(t, err)
+
+				address := v1.EndpointAddress{
+					IP: tc.hostIPs[i],
+					TargetRef: &v1.ObjectReference{
+						APIVersion: "",
+						Kind:       "Pod",
+						Name:       podname,
+					},
+				}
+				if tc.podsReady[i] {
+					addresses = append(addresses, address)
+				} else {
+					notReadyAddresses = append(notReadyAddresses, address)
+				}
+			}
+			endpointsObject := &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tc.svcNamespace,
+					Name:      tc.svcName,
+					Labels:    tc.labels,
+				},
+				Subsets: []v1.EndpointSubset{
+					{
+						Addresses:         addresses,
+						NotReadyAddresses: notReadyAddresses,
+					},
+				},
+			}
+			_, err = kubernetes.CoreV1().Endpoints(tc.svcNamespace).Create(context.Background(), endpointsObject, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			// Create our object under test and get the endpoints.
+			client, _ := NewServiceSource(
+				kubernetes,
+				tc.targetNamespace,
+				"",
+				tc.fqdnTemplate,
+				false,
+				tc.compatibility,
+				true,
+				false,
+				false,
+				[]string{},
+				tc.ignoreHostnameAnnotation,
+			)
+			require.NoError(t, err)
+
+			endpoints, err := client.Endpoints(context.Background())
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, endpoints, tc.expected)
+		})
+	}
+}
+
 // TestExternalServices tests that external services generate the correct endpoints.
 func TestExternalServices(t *testing.T) {
 	t.Parallel()

--- a/source/source.go
+++ b/source/source.go
@@ -50,6 +50,8 @@ const (
 	ttlAnnotationKey = "external-dns.alpha.kubernetes.io/ttl"
 	// The annotation used for switching to the alias record types e. g. AWS Alias records instead of a normal CNAME
 	aliasAnnotationKey = "external-dns.alpha.kubernetes.io/alias"
+	// The annotation used for having publishHostIP use the ExternalIP of the Host Node
+	externalIPAnnotationKey = "external-dns.alpha.kubernetes.io/use-external-host-ip"
 	// The annotation used to determine the source of hostnames for ingresses.  This is an optional field - all
 	// available hostname sources are used if not specified.
 	ingressHostnameSourceKey = "external-dns.alpha.kubernetes.io/ingress-hostname-source"
@@ -161,6 +163,11 @@ func getInternalHostnamesFromAnnotations(annotations map[string]string) []string
 
 func getAliasFromAnnotations(annotations map[string]string) bool {
 	aliasAnnotation, exists := annotations[aliasAnnotationKey]
+	return exists && aliasAnnotation == "true"
+}
+
+func getExternalIPFromAnnotations(annotations map[string]string) bool {
+	aliasAnnotation, exists := annotations[externalIPAnnotationKey]
 	return exists && aliasAnnotation == "true"
 }
 


### PR DESCRIPTION
Support  exposing `ExternalIP` of a Node via `external-dns.alpha.kubernetes.io/use-external-host-ip` on the service (`--publish-host-ip` needs to be set too).

Example service:
```yaml
apiVersion: v1
kind: Service
metadata:
  name: kafka-svc
  annotations:
    external-dns.alpha.kubernetes.io/hostname:  kafka-svc.example.com
    external-dns.alpha.kubernetes.io/use-external-host-ip: "true"
spec:
  ports:
  - port: 9092
    name: kafka-tls
  selector:
    app: kafka
  clusterIP: None
```